### PR TITLE
fix some error exception

### DIFF
--- a/certbot_regru/dns.py
+++ b/certbot_regru/dns.py
@@ -89,7 +89,8 @@ class _RegRuClient(object):
             logger.error('Encountered error adding TXT record: %d %s', e, e)
             raise errors.PluginError('Error communicating with the Reg.ru API: {0}'.format(e))
 
-        if 'result' not in response or response['result'] != 'success':
+        if 'result' not in response or response['result'] != 'success' \
+                or response['answer']['domains'][0]['result'] != 'success':
             logger.error('Encountered error adding TXT record: %s', response)
             raise errors.PluginError('Error communicating with the Reg.ru API: {0}'.format(response))
 
@@ -117,7 +118,8 @@ class _RegRuClient(object):
             logger.warning('Encountered error deleting TXT record: %s', e)
             return
 
-        if 'result' not in response or response['result'] != 'success':
+        if 'result' not in response or response['result'] != 'success' \
+                or response['answer']['domains'][0]['result'] != 'success':
             logger.warning('Encountered error deleting TXT record: %s', response)
             return
 


### PR DESCRIPTION
By some resons as domain use other ns servers
anser from api can be like:
`{
"answer" : {
"domains" : [
{
"dname" : "example.ru",
"error_code" : "DOMAIN_IS_NOT_USE_REGRU_NSS",
"error_text" : "This domain not use REG.RU name services",
"result" : "error",
"service_id" : "2265012",
"servtype" : "domain"
}
]
},
"charset" : "utf-8",
"messagestore" : null,
"result" : "success"
}`
and no exception will be thrown
this commit fix it